### PR TITLE
Ensure rake v10 when using ruby 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-gem 'rake'
 gem 'librarian-puppet-simple'
+
+# rake >= 11 does not support ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rake', '~> 10.0'
+end


### PR DESCRIPTION
Rake v11 drops support for ruby 1.8.7